### PR TITLE
fixes a case error

### DIFF
--- a/src/web/GeomanAsset.php
+++ b/src/web/GeomanAsset.php
@@ -43,7 +43,7 @@ class GeomanAsset extends AssetBundle
 			];
 
 			$this->js = [
-				'js/geoman.js'
+				'js/Geoman.js'
 			];
 		}
 


### PR DESCRIPTION
This fixes a 404 with attempting to retrieve `Geoman.js` from `cpresources` (it's looking for `geoman.js`, lowercased, which does not exist.)